### PR TITLE
feat: add environment variable overrides for platform enabled flags and agent type

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,15 @@ DISCORD_TOKEN=your-discord-bot-token
 MISSKEY_TOKEN=your-misskey-access-token
 MISSKEY_HOST=misskey.example.com
 
+# Platform enable flags (true/false). These can override the corresponding
+DISCORD_ENABLED=true
+MISSKEY_ENABLED=false
+
 # Agent configuration
 AGENT_MODEL=gpt-5-mini
+
+# Default ACP agent type (copilot|gemini|opencode)
+AGENT_DEFAULT_TYPE=copilot
 
 # Logging
 LOG_LEVEL=INFO

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,7 +9,7 @@ logging:
 # Platform configurations
 platforms:
   discord:
-    enabled: true # true/false (default: false)
+    enabled: true # true/false (default: false); override with env DISCORD_ENABLED
     token: "${DISCORD_TOKEN}" # Bot token; use environment variable DISCORD_TOKEN or set here
     guildIds: [] # List of guild IDs to operate in (empty = all)
     allowDm: true # Respond to direct messages (default: true)
@@ -17,7 +17,7 @@ platforms:
     commandPrefix: "!" # Optional command prefix (set empty to disable)
 
   misskey:
-    enabled: false # true/false (default: false)
+    enabled: false # true/false (default: false); override with env MISSKEY_ENABLED
     host: "${MISSKEY_HOST}" # e.g., misskey.example.com - or set via MISSKEY_HOST env var
     token: "${MISSKEY_TOKEN}" # API token (preferred via MISSKEY_TOKEN env var)
     secure: true # Use wss/https when connecting (true/false, default: true)
@@ -38,7 +38,7 @@ agent:
   githubToken: "${GITHUB_TOKEN}" # Optional GitHub token for Copilot (env: GITHUB_TOKEN)
   geminiApiKey: "${GEMINI_API_KEY}" # Optional Gemini API key (env: GEMINI_API_KEY)
   opencodeApiKey: "${OPENCODE_API_KEY}" # Optional OpenCode API key (env: OPENCODE_API_KEY)
-  defaultAgentType: "copilot" # Default ACP agent: "copilot", "gemini", or "opencode"
+  defaultAgentType: "copilot" # Default ACP agent: "copilot", "gemini", or "opencode" (env: AGENT_DEFAULT_TYPE)
 
 # Memory system configuration
 memory:

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -5,8 +5,10 @@
  */
 export const ENV_MAPPINGS = {
   DISCORD_TOKEN: "platforms.discord.token",
+  DISCORD_ENABLED: "platforms.discord.enabled",
   MISSKEY_TOKEN: "platforms.misskey.token",
   MISSKEY_HOST: "platforms.misskey.host",
+  MISSKEY_ENABLED: "platforms.misskey.enabled",
   AGENT_MODEL: "agent.model",
   AGENT_API_KEY: "agent.apiKey",
   GITHUB_TOKEN: "agent.githubToken",

--- a/tests/core/config-loader.test.ts
+++ b/tests/core/config-loader.test.ts
@@ -101,6 +101,93 @@ workspace:
   }
 });
 
+Deno.test("loadConfig - DISCORD_ENABLED env overrides config file", async () => {
+  const config = `
+platforms:
+  discord:
+    token: "test-token"
+    enabled: false
+  misskey:
+    enabled: false
+agent:
+  model: "gpt-4"
+  systemPromptPath: "./prompts/system.md"
+  tokenLimit: 4096
+workspace:
+  repoPath: "./data"
+  workspacesDir: "workspaces"
+`;
+
+  Deno.env.set("DISCORD_ENABLED", "true");
+  try {
+    await withTestConfig(config, async (dir) => {
+      const result = await loadConfig(dir);
+      assertEquals(result.platforms.discord.enabled, true);
+    });
+  } finally {
+    Deno.env.delete("DISCORD_ENABLED");
+  }
+});
+
+Deno.test("loadConfig - MISSKEY_ENABLED env overrides config file", async () => {
+  const config = `
+platforms:
+  discord:
+    token: "test-token"
+    enabled: false
+  misskey:
+    host: "misskey.example.com"
+    token: "mk-token"
+    enabled: false
+agent:
+  model: "gpt-4"
+  systemPromptPath: "./prompts/system.md"
+  tokenLimit: 4096
+workspace:
+  repoPath: "./data"
+  workspacesDir: "workspaces"
+`;
+
+  Deno.env.set("MISSKEY_ENABLED", "true");
+  try {
+    await withTestConfig(config, async (dir) => {
+      const result = await loadConfig(dir);
+      assertEquals(result.platforms.misskey.enabled, true);
+    });
+  } finally {
+    Deno.env.delete("MISSKEY_ENABLED");
+  }
+});
+
+Deno.test("loadConfig - AGENT_DEFAULT_TYPE env overrides config file", async () => {
+  const config = `
+platforms:
+  discord:
+    token: "test-token"
+    enabled: true
+  misskey:
+    enabled: false
+agent:
+  model: "gpt-4"
+  systemPromptPath: "./prompts/system.md"
+  tokenLimit: 4096
+  defaultAgentType: "copilot"
+workspace:
+  repoPath: "./data"
+  workspacesDir: "workspaces"
+`;
+
+  Deno.env.set("AGENT_DEFAULT_TYPE", "opencode");
+  try {
+    await withTestConfig(config, async (dir) => {
+      const result = await loadConfig(dir);
+      assertEquals(result.agent.defaultAgentType, "opencode");
+    });
+  } finally {
+    Deno.env.delete("AGENT_DEFAULT_TYPE");
+  }
+});
+
 Deno.test("loadConfig - should throw on missing required fields", async () => {
   const config = `
 platforms:

--- a/tests/utils/env.test.ts
+++ b/tests/utils/env.test.ts
@@ -1,0 +1,83 @@
+// tests/utils/env.test.ts
+
+import { assertEquals } from "@std/assert";
+import { applyEnvOverrides, setNestedProperty } from "@utils/env.ts";
+
+Deno.test("setNestedProperty - sets deeply nested value", () => {
+  const obj: Record<string, unknown> = {};
+  setNestedProperty(obj, "platforms.discord.enabled", true);
+  assertEquals(
+    (obj as { platforms: { discord: { enabled: boolean } } }).platforms.discord.enabled,
+    true,
+  );
+});
+
+Deno.test("applyEnvOverrides - DISCORD_ENABLED=true sets platforms.discord.enabled to boolean true", () => {
+  Deno.env.set("DISCORD_ENABLED", "true");
+  try {
+    const config: Record<string, unknown> = {
+      platforms: { discord: { enabled: false, token: "tok" }, misskey: { enabled: false } },
+    };
+    applyEnvOverrides(config);
+    const platforms = config.platforms as { discord: { enabled: boolean } };
+    assertEquals(platforms.discord.enabled, true);
+  } finally {
+    Deno.env.delete("DISCORD_ENABLED");
+  }
+});
+
+Deno.test("applyEnvOverrides - DISCORD_ENABLED=false sets platforms.discord.enabled to boolean false", () => {
+  Deno.env.set("DISCORD_ENABLED", "false");
+  try {
+    const config: Record<string, unknown> = {
+      platforms: { discord: { enabled: true, token: "tok" }, misskey: { enabled: false } },
+    };
+    applyEnvOverrides(config);
+    const platforms = config.platforms as { discord: { enabled: boolean } };
+    assertEquals(platforms.discord.enabled, false);
+  } finally {
+    Deno.env.delete("DISCORD_ENABLED");
+  }
+});
+
+Deno.test("applyEnvOverrides - MISSKEY_ENABLED=true sets platforms.misskey.enabled to boolean true", () => {
+  Deno.env.set("MISSKEY_ENABLED", "true");
+  try {
+    const config: Record<string, unknown> = {
+      platforms: { discord: { enabled: false, token: "tok" }, misskey: { enabled: false } },
+    };
+    applyEnvOverrides(config);
+    const platforms = config.platforms as { misskey: { enabled: boolean } };
+    assertEquals(platforms.misskey.enabled, true);
+  } finally {
+    Deno.env.delete("MISSKEY_ENABLED");
+  }
+});
+
+Deno.test("applyEnvOverrides - AGENT_DEFAULT_TYPE sets agent.defaultAgentType", () => {
+  Deno.env.set("AGENT_DEFAULT_TYPE", "gemini");
+  try {
+    const config: Record<string, unknown> = {
+      agent: { defaultAgentType: "copilot" },
+    };
+    applyEnvOverrides(config);
+    const agent = config.agent as { defaultAgentType: string };
+    assertEquals(agent.defaultAgentType, "gemini");
+  } finally {
+    Deno.env.delete("AGENT_DEFAULT_TYPE");
+  }
+});
+
+Deno.test("applyEnvOverrides - empty env var does not override", () => {
+  Deno.env.set("DISCORD_ENABLED", "");
+  try {
+    const config: Record<string, unknown> = {
+      platforms: { discord: { enabled: true, token: "tok" }, misskey: { enabled: false } },
+    };
+    applyEnvOverrides(config);
+    const platforms = config.platforms as { discord: { enabled: boolean } };
+    assertEquals(platforms.discord.enabled, true);
+  } finally {
+    Deno.env.delete("DISCORD_ENABLED");
+  }
+});


### PR DESCRIPTION
- Add DISCORD_ENABLED and MISSKEY_ENABLED env mappings to override platform enabled settings
- Add AGENT_DEFAULT_TYPE env mapping (already existed but now documented)
- Update config.example.yaml with env override comments
- Add .env.example entries with examples and descriptions
- Add comprehensive unit and integration tests for new env overrides

This allows users to enable/disable platforms and set agent type via environment variables without editing config files.